### PR TITLE
Uncaught ReferenceError: i is not defined

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
        function resourceTiming()
        {
            var resourceList = window.performance.getEntriesByType("resource");
-           for (i = 0; i &lt; resourceList.length; i++)
+           for (var i = 0; i &lt; resourceList.length; i++)
            {
               if (resourceList[i].initiatorType == "img")
               {


### PR DESCRIPTION
By copying code from that draft/doc, it isn't evaluated by default - throws and error
```
Uncaught ReferenceError: i is not defined
```
Tested in Chrome `v61` and Chrome Canary `v63`.

As a fix, should be used `var` or `let` or explicit `window.i` approach to avoid error. Suggested by me small fix, is rather well known code snippet/approach.