### PR TITLE
Removing unnecessary spans from example #7

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,40 +371,44 @@ worker</span><span class="pun">.</span><span class="pln">port</span><span class=
           <p>
             Here's a simple example that explains how a developer can use the interfaces defined in this document to obtain timing data related to developer scripts.
           </p>
-          <pre class="example highlight prettyprint prettyprinted"><span class="dec">&lt;!doctype html&gt;</span><span class="pln">
-</span><span class="tag">&lt;html&gt;</span><span class="pln">
-  </span><span class="tag">&lt;head&gt;</span><span class="pln">
-    </span><span class="tag">&lt;title&gt;</span><span class="pln">User Timing example</span><span class="tag">&lt;/title&gt;</span><span class="pln">
-  </span><span class="tag">&lt;/head&gt;</span><span class="pln">
-  </span><span class="tag">&lt;body</span><span class="pln"> </span><span class="atn">onload</span><span class="pun">=</span><span class="atv">"</span><span class="pln">init</span><span class="pun">()</span><span class="atv">"</span><span class="tag">&gt;</span><span class="pln">
-    </span><span class="tag">&lt;script&gt;</span><span class="pln">
-       </span><span class="kwd">function</span><span class="pln"> init</span><span class="pun">()</span><span class="pln">
-       </span><span class="pun">{</span><span class="pln">
-            performance</span><span class="pun">.</span><span class="pln">mark</span><span class="pun">(</span><span class="str">"startTask1"</span><span class="pun">);</span><span class="pln">
-            doTask1</span><span class="pun">();</span><span class="pln"> </span><span class="com">// Some developer code</span><span class="pln">
-            performance</span><span class="pun">.</span><span class="pln">mark</span><span class="pun">(</span><span class="str">"endTask1"</span><span class="pun">);</span><span class="pln">
+          <pre class="example highlight">
+            &lt;!doctype html&gt;
+            &lt;html&gt;
+            &lt;head&gt;
+              &lt;title&gt;User Timing example &lt;/title&gt;
+            &lt;/head&gt;
+            &lt;body onload="init()"&gt;
+            &lt;script&gt;
+              function init()
+              {
+                performance.mark("startTask1");
+                doTask1(); // Some developer code.
+                performance.mark("endTask1");
 
-            performance</span><span class="pun">.</span><span class="pln">mark</span><span class="pun">(</span><span class="str">"startTask2"</span><span class="pun">);</span><span class="pln">
-            doTask2</span><span class="pun">();</span><span class="pln"> </span><span class="com">// Some developer code</span><span class="pln">
-            performance</span><span class="pun">.</span><span class="pln">mark</span><span class="pun">(</span><span class="str">"endTask2"</span><span class="pun">);</span><span class="pln">
+                performance.mark("startTask2");
+                doTask2(); // Some developer code.
+                performance.mark("endTask2");
 
-            measurePerf</span><span class="pun">();</span><span class="pln">
-       </span><span class="pun">}</span><span class="pln">
+                measurePerf();
+              }
 
-       </span><span class="kwd">function</span><span class="pln"> measurePerf</span><span class="pun">()</span><span class="pln">
-       </span><span class="pun">{</span><span class="pln">
-           </span><span class="kwd">var</span><span class="pln"> perfEntries </span><span class="pun">=</span><span class="pln"> performance</span><span class="pun">.</span><span class="pln">getEntriesByType</span><span class="pun">(</span><span class="str">"mark"</span><span class="pun">);</span><span class="pln">
-           </span><span class="kwd">for</span><span class="pln"> </span><span class="pun">(</span><span class="kwd">var</span><span class="pln"> i </span><span class="pun">=</span><span class="pln"> </span><span class="lit">0</span><span class="pun">;</span><span class="pln"> i </span><span class="pun">&lt;</span><span class="pln"> perfEntries</span><span class="pun">.</span><span class="pln">length</span><span class="pun">;</span><span class="pln"> i</span><span class="pun">++)</span><span class="pln">
-           </span><span class="pun">{</span><span class="pln">
-                 </span><span class="kwd">if</span><span class="pln"> </span><span class="pun">(</span><span class="pln">window</span><span class="pun">.</span><span class="pln">console</span><span class="pun">)</span><span class="pln"> console</span><span class="pun">.</span><span class="pln">log</span><span class="pun">(</span><span class="str">"Name: "</span><span class="pln">        </span><span class="pun">+</span><span class="pln"> perfEntries</span><span class="pun">[</span><span class="pln">i</span><span class="pun">].</span><span class="pln">name      </span><span class="pun">+</span><span class="pln">
-                                                 </span><span class="str">" Entry Type: "</span><span class="pln"> </span><span class="pun">+</span><span class="pln"> perfEntries</span><span class="pun">[</span><span class="pln">i</span><span class="pun">].</span><span class="pln">entryType </span><span class="pun">+</span><span class="pln">
-                                                 </span><span class="str">" Start Time: "</span><span class="pln"> </span><span class="pun">+</span><span class="pln"> perfEntries</span><span class="pun">[</span><span class="pln">i</span><span class="pun">].</span><span class="pln">startTime </span><span class="pun">+</span><span class="pln">
-                                                 </span><span class="str">" Duration: "</span><span class="pln">   </span><span class="pun">+</span><span class="pln"> perfEntries</span><span class="pun">[</span><span class="pln">i</span><span class="pun">].</span><span class="pln">duration  </span><span class="pun">+</span><span class="pln"> </span><span class="str">"\n"</span><span class="pun">);</span><span class="pln">
-           </span><span class="pun">}</span><span class="pln">
-       </span><span class="pun">}</span><span class="pln">
-    </span><span class="tag">&lt;/script&gt;</span><span class="pln">
-  </span><span class="tag">&lt;/body&gt;</span><span class="pln">
-</span><span class="tag">&lt;/html&gt;</span></pre>
+              function measurePerf()
+              {
+                var perfEntries = performance.getEntriesByType("mark");
+                for (var i = 0; i &lt; perfEntries.length; i++)
+                {
+                  if (window.console) {
+                    console.log("Name: "        + perfEntries[i].name +
+                                " Entry Type: " + perfEntries[i].entryType +
+                                " Start Time: " + perfEntries[i].startTime +
+                                " Duration: "   + perfEntries[i].duration  + "\n");
+                  }
+                }
+              }
+            &lt;/script&gt;
+            &lt;/body&gt;
+            &lt;/html&gt;
+          </pre>
         </section>
         <section>
           <h3>performance.mark()</h3>


### PR DESCRIPTION
It looks like the example code was copied from a render output (post code highlight). So it had all the extra spans in the source. 

This cleans up the source code but it also has the added benefit of also fixing the highlight (which wasn't working before because of the spans).

Note: I kept the styling the same as it was before but it's not really consistent with other examples in the perf specs, let me know. I can clean that up.

### Before:

<img width="865" alt="screen shot 2018-01-06 at 10 12 47 pm" src="https://user-images.githubusercontent.com/118016/34646162-c30d5bfa-f32e-11e7-9600-c09f7ee38a70.png">

### After:
<img width="874" alt="screen shot 2018-01-06 at 10 09 02 pm" src="https://user-images.githubusercontent.com/118016/34646165-d345d632-f32e-11e7-8b0a-ebf1d1b8c500.png">

  