### PR TITLE
fix a typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     <section>
       <h2>Overview</h2>
       <p>
-        Imagine you're visiting our W3C website, if the web content doesn't show up in the screeen within a certain number of seconds, as a user, perhaps you will just close the tab and head to alternatives. However, as a developer, you might hope to trace the hints in the requests and navigation details, so that you can find out what's slowing down this webpage.
+        Imagine you're visiting our W3C website, if the web content doesn't show up in the screen within a certain number of seconds, as a user, perhaps you will just close the tab and head to alternatives. However, as a developer, you might hope to trace the hints in the requests and navigation details, so that you can find out what's slowing down this webpage.
       </p>
       <p>
         Fortunately, most browser vendors are willing to expose performance characteristics that allow developers to collect accurate performance details. These performance timing APIs, as their names suggest, are very helpful to identify the bottlenecks of the web applications from different aspects and improve the performance.


### PR DESCRIPTION
'screeen' should be 'screen'